### PR TITLE
Upgrade to Rails 6.1 compatibility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SQLAnywhere ActiveRecord
 
-This is a SQLAnywhere driver for ActiveRecord 6.0.
+This is a SQLAnywhere driver for ActiveRecord 6.1.
 This driver supports SQLAnywhere 16 and 17.
 This driver requires the `SQLAnywhere2` ruby gem.
 

--- a/activerecord-sqlanywhere-adapter.gemspec
+++ b/activerecord-sqlanywhere-adapter.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "sqlanywhere2", ">= 0.0.7"
-  spec.add_runtime_dependency "activerecord", ">= 6.0.0", "< 6.1"
+  spec.add_runtime_dependency "activerecord", "~> 6.1"
   spec.required_ruby_version = ">= 2.0.0"
 end

--- a/lib/active_record/connection_adapters/abstract/transaction_extension.rb
+++ b/lib/active_record/connection_adapters/abstract/transaction_extension.rb
@@ -22,10 +22,9 @@ module ActiveRecord
 
     module SQLAnywhereRealTransaction
       attr_reader :starting_sqlanywhere_isolation_level
-
-      def initialize(connection, options, **args)
+      def initialize(connection, isolation: nil, joinable: true, run_commit_callbacks: false)
         @connection = connection
-        @starting_sqlanywhere_isolation_level = current_sqlanywhere_isolation_level if options[:isolation]
+        @starting_sqlanywhere_isolation_level = current_sqlanywhere_isolation_level if isolation
         super
       end
 


### PR DESCRIPTION
`RealTransaction` init method has changed between versions.

This prevents `ArgumentError (wrong number of arguments (given 2, expected 1)`. Caused by named argument differences between versions. This errors only when updating any Model that then errors, due to validation for example.

https://github.com/rails/rails/blob/6-0-stable/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb#L78
https://github.com/rails/rails/blob/6-1-stable/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb#L89